### PR TITLE
Fix compatibility issue in evaluate_word.py

### DIFF
--- a/evaluation/evaluate_word.py
+++ b/evaluation/evaluate_word.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='SIGMORPHON 2022 Morpheme Segmentation Shared Task Evaluation')
     parser.add_argument("--gold", help="Gold standard", required=True, type=str)
     parser.add_argument("--guess", help="Model output", required=True, type=str)
-    parser.add_argument("--category", help="Morphological category", default=False,  action=argparse.BooleanOptionalAction)
+    parser.add_argument("--category", help="Morphological category", action="store_true")
     args = parser.parse_args()    
 
     D_gold, D_cat = read(args.gold, args.category)


### PR DESCRIPTION
Hello,

Thank you for organizing this task. I noticed a small issue in `evaluate_word.py`: it uses `action=argparse.BooleanOptionalAction`, which was only added in python 3.9. In order to make things more convenient to those of use using other versions of python, this can be replaced by `action='store_true'`, which has the same functionality.