### PR TITLE
More efficient indexing for faster levenshtein computation

### DIFF
--- a/evaluation/evaluate_word.py
+++ b/evaluation/evaluate_word.py
@@ -11,19 +11,19 @@ import codecs
 
 def distance(str1, str2):
     """Simple Levenshtein implementation for evalm."""
-    m = np.zeros([len(str2)+1, len(str1)+1])
+    m = np.zeros([len(str2) + 1, len(str1) + 1], dtype=int)
     for x in range(1, len(str2) + 1):
-        m[x][0] = m[x-1][0] + 1
+        m[x, 0] = m[x - 1, 0] + 1
     for y in range(1, len(str1) + 1):
-        m[0][y] = m[0][y-1] + 1
+        m[0, y] = m[0, y - 1] + 1
     for x in range(1, len(str2) + 1):
         for y in range(1, len(str1) + 1):
             if str1[y-1] == str2[x-1]:
                 dg = 0
             else:
                 dg = 1
-            m[x][y] = min(m[x-1][y] + 1, m[x][y-1] + 1, m[x-1][y-1] + dg)
-    return int(m[len(str2)][len(str1)])
+            m[x, y] = min(m[x - 1, y] + 1, m[x, y - 1] + 1, m[x - 1, y - 1] + dg)
+    return m[len(str2), len(str1)]
 
 def read(fname, flag):
     """ read file name """


### PR DESCRIPTION
Hello,

When accessing values in an ndarray m, it is more efficient to do `m[i, j]` than `m[i][j]`. The latter needs to create a temporary array `m[i]`, while the former does not.

Using the more efficient indexing reduced the runtime to evaluate the English baseline from~15s to ~11s on my laptop.

I also changed the dtype of the dynamic programming chart -- at all steps, the values in the chart will be integers, so it makes more sense to instantiate it that way than to make it a float array and cast the result to int. This change also seems to have shaved a half-second or so off the runtime.