### PR TITLE
Treat whitespace as a morpheme boundary

### DIFF
--- a/evaluation/evaluate_word.py
+++ b/evaluation/evaluate_word.py
@@ -44,6 +44,7 @@ def read_tsv(path, category):
             for name, field in zip(col_names, fields):
                 if name == "segments":
                     field = field.replace(' @@', '|')
+                    field = field.replace(' ', '|')
                 data[name].append(field)
     return data
 

--- a/evaluation/evaluate_word.py
+++ b/evaluation/evaluate_word.py
@@ -40,7 +40,7 @@ def read_tsv(path, category):
     data = {name: [] for name in col_names}
     with open(path) as f:
         for line in f:
-            fields = line.strip().split("\t")
+            fields = line.rstrip("\n").split("\t")
             for name, field in zip(col_names, fields):
                 if name == "segments":
                     field = field.replace(' @@', '|')


### PR DESCRIPTION
This pull request causes whitespace to be treated as a morpheme boundary for evaluation purposes.

It also fixes a bug when the predicted sequence is empty and no `--category` is false. Before the bug was fixed, the script would crash in this case. Now, it correctly evaluates the empty string as the model's (very bad) prediction.